### PR TITLE
Add Checked handle abstraction and validate cross-graph/generation safety across storages and topologies

### DIFF
--- a/src/graph/handle.rs
+++ b/src/graph/handle.rs
@@ -57,3 +57,66 @@ impl VertexHandle {
         self.graph
     }
 }
+
+pub trait Handle: Copy {
+    fn index(&self) -> usize;
+    fn generation(&self) -> u32;
+    fn graph(&self) -> u32;
+}
+
+impl Handle for VertexHandle {
+    fn index(&self) -> usize {
+        self.index()
+    }
+
+    fn generation(&self) -> u32 {
+        self.generation()
+    }
+
+    fn graph(&self) -> u32 {
+        self.graph()
+    }
+}
+
+impl Handle for EdgeHandle {
+    fn index(&self) -> usize {
+        self.index()
+    }
+
+    fn generation(&self) -> u32 {
+        self.generation()
+    }
+
+    fn graph(&self) -> u32 {
+        self.graph()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Checked<T: Handle>(T);
+
+impl<T: Handle> Checked<T> {
+    pub fn generation(handle: T) -> Option<Self> {
+        if handle.generation() == 1 {
+            return Some(Self(handle));
+        }
+
+        None
+    }
+
+    pub fn graph_and_generation(handle: T, graph: u32) -> Option<Self> {
+        if handle.graph() == graph {
+            return Self::generation(handle);
+        }
+
+        None
+    }
+
+    pub fn index(&self) -> usize {
+        self.0.index()
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -6,6 +6,6 @@ mod topology;
 
 pub use algorithm::*;
 pub use graph::{BasicGraph, Graph, GraphMut};
-pub use handle::{EdgeHandle, VertexHandle};
+pub use handle::{Checked, EdgeHandle, Handle, VertexHandle};
 pub use storage::*;
 pub use topology::{HashMapTopology, Topology, TopologyMut, Undirected, VecTopology};

--- a/src/graph/storage/hash_map.rs
+++ b/src/graph/storage/hash_map.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use crate::graph::{EdgeHandle, Storage, VertexHandle};
+use crate::graph::{Checked, EdgeHandle, Storage, VertexHandle};
 
 static DISCRIMINANT_COUNTER: AtomicU32 = AtomicU32::new(0);
 
@@ -22,6 +22,14 @@ impl<V, E> HashMapStorage<V, E> {
             vertices: HashMap::new(),
         }
     }
+
+    fn checked_vertex(&self, handle: VertexHandle) -> Option<Checked<VertexHandle>> {
+        Checked::graph_and_generation(handle, self.discriminant)
+    }
+
+    fn checked_edge(&self, handle: EdgeHandle) -> Option<Checked<EdgeHandle>> {
+        Checked::graph_and_generation(handle, self.discriminant)
+    }
 }
 
 impl<V, E> Storage for HashMapStorage<V, E> {
@@ -29,53 +37,33 @@ impl<V, E> Storage for HashMapStorage<V, E> {
     type Edge = E;
 
     fn vertex(&self, handle: VertexHandle) -> Option<&V> {
-        if handle.graph() != self.discriminant {
-            return None;
-        }
-
-        self.vertices.get(&handle)
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.get(&checked.into_inner())
     }
 
     fn edge(&self, handle: EdgeHandle) -> Option<&E> {
-        if handle.graph() != self.discriminant {
-            return None;
-        }
-
-        self.edges.get(&handle)
+        let checked = self.checked_edge(handle)?;
+        self.edges.get(&checked.into_inner())
     }
 
     fn vertex_mut(&mut self, handle: VertexHandle) -> Option<&mut V> {
-        if handle.graph() != self.discriminant {
-            return None;
-        }
-
-        self.vertices.get_mut(&handle)
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.get_mut(&checked.into_inner())
     }
 
     fn edge_mut(&mut self, handle: EdgeHandle) -> Option<&mut E> {
-        if handle.graph() != self.discriminant {
-            return None;
-        }
-
-        self.edges.get_mut(&handle)
+        let checked = self.checked_edge(handle)?;
+        self.edges.get_mut(&checked.into_inner())
     }
 
     fn set_vertex(&mut self, handle: VertexHandle, vertex: V) -> Option<V> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "vertex handle graph mismatch"
-        );
-        self.vertices.insert(handle, vertex)
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.insert(checked.into_inner(), vertex)
     }
 
     fn set_edge(&mut self, handle: EdgeHandle, edge: E) -> Option<E> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "edge handle graph mismatch"
-        );
-        self.edges.insert(handle, edge)
+        let checked = self.checked_edge(handle)?;
+        self.edges.insert(checked.into_inner(), edge)
     }
 
     fn add_vertex(&mut self, vertex: V) -> VertexHandle {
@@ -91,20 +79,12 @@ impl<V, E> Storage for HashMapStorage<V, E> {
     }
 
     fn remove_vertex(&mut self, handle: VertexHandle) -> Option<V> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "vertex handle graph mismatch"
-        );
-        self.vertices.remove(&handle)
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.remove(&checked.into_inner())
     }
 
     fn remove_edge(&mut self, handle: EdgeHandle) -> Option<E> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "edge handle graph mismatch"
-        );
-        self.edges.remove(&handle)
+        let checked = self.checked_edge(handle)?;
+        self.edges.remove(&checked.into_inner())
     }
 }

--- a/src/graph/storage/vec.rs
+++ b/src/graph/storage/vec.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use crate::graph::{EdgeHandle, Storage, VertexHandle};
+use crate::graph::{Checked, EdgeHandle, Storage, VertexHandle};
 
 static DISCRIMINANT_COUNTER: AtomicU32 = AtomicU32::new(10_000);
 
@@ -20,30 +20,22 @@ impl<V, E> VecStorage<V, E> {
         }
     }
 
-    fn valid_vertex_handle(&self, handle: VertexHandle) -> Option<usize> {
-        if handle.graph() != self.discriminant {
+    fn checked_vertex(&self, handle: VertexHandle) -> Option<Checked<VertexHandle>> {
+        let checked = Checked::graph_and_generation(handle, self.discriminant)?;
+        if checked.index() >= self.vertices.len() {
             return None;
         }
 
-        let index = handle.index();
-        if index >= self.vertices.len() {
-            return None;
-        }
-
-        Some(index)
+        Some(checked)
     }
 
-    fn valid_edge_handle(&self, handle: EdgeHandle) -> Option<usize> {
-        if handle.graph() != self.discriminant {
+    fn checked_edge(&self, handle: EdgeHandle) -> Option<Checked<EdgeHandle>> {
+        let checked = Checked::graph_and_generation(handle, self.discriminant)?;
+        if checked.index() >= self.edges.len() {
             return None;
         }
 
-        let index = handle.index();
-        if index >= self.edges.len() {
-            return None;
-        }
-
-        Some(index)
+        Some(checked)
     }
 }
 
@@ -52,23 +44,23 @@ impl<V, E> Storage for VecStorage<V, E> {
     type Edge = E;
 
     fn vertex(&self, handle: VertexHandle) -> Option<&Self::Vertex> {
-        let index = self.valid_vertex_handle(handle)?;
-        self.vertices.get(index)?.as_ref()
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.get(checked.index())?.as_ref()
     }
 
     fn edge(&self, handle: EdgeHandle) -> Option<&Self::Edge> {
-        let index = self.valid_edge_handle(handle)?;
-        self.edges.get(index)?.as_ref()
+        let checked = self.checked_edge(handle)?;
+        self.edges.get(checked.index())?.as_ref()
     }
 
     fn vertex_mut(&mut self, handle: VertexHandle) -> Option<&mut Self::Vertex> {
-        let index = self.valid_vertex_handle(handle)?;
-        self.vertices.get_mut(index)?.as_mut()
+        let checked = self.checked_vertex(handle)?;
+        self.vertices.get_mut(checked.index())?.as_mut()
     }
 
     fn edge_mut(&mut self, handle: EdgeHandle) -> Option<&mut Self::Edge> {
-        let index = self.valid_edge_handle(handle)?;
-        self.edges.get_mut(index)?.as_mut()
+        let checked = self.checked_edge(handle)?;
+        self.edges.get_mut(checked.index())?.as_mut()
     }
 
     fn add_vertex(&mut self, vertex: Self::Vertex) -> VertexHandle {
@@ -84,62 +76,22 @@ impl<V, E> Storage for VecStorage<V, E> {
     }
 
     fn set_vertex(&mut self, handle: VertexHandle, vertex: Self::Vertex) -> Option<Self::Vertex> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "vertex handle graph mismatch"
-        );
-
-        let index = handle.index();
-        if index >= self.vertices.len() {
-            return None;
-        }
-
-        self.vertices[index].replace(vertex)
+        let checked = self.checked_vertex(handle)?;
+        self.vertices[checked.index()].replace(vertex)
     }
 
     fn set_edge(&mut self, handle: EdgeHandle, edge: Self::Edge) -> Option<Self::Edge> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "edge handle graph mismatch"
-        );
-
-        let index = handle.index();
-        if index >= self.edges.len() {
-            return None;
-        }
-
-        self.edges[index].replace(edge)
+        let checked = self.checked_edge(handle)?;
+        self.edges[checked.index()].replace(edge)
     }
 
     fn remove_vertex(&mut self, handle: VertexHandle) -> Option<Self::Vertex> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "vertex handle graph mismatch"
-        );
-
-        let index = handle.index();
-        if index >= self.vertices.len() {
-            return None;
-        }
-
-        self.vertices[index].take()
+        let checked = self.checked_vertex(handle)?;
+        self.vertices[checked.index()].take()
     }
 
     fn remove_edge(&mut self, handle: EdgeHandle) -> Option<Self::Edge> {
-        assert_eq!(
-            handle.graph(),
-            self.discriminant,
-            "edge handle graph mismatch"
-        );
-
-        let index = handle.index();
-        if index >= self.edges.len() {
-            return None;
-        }
-
-        self.edges[index].take()
+        let checked = self.checked_edge(handle)?;
+        self.edges[checked.index()].take()
     }
 }

--- a/src/graph/topology/hash_map.rs
+++ b/src/graph/topology/hash_map.rs
@@ -3,7 +3,7 @@ use std::{
     iter::Copied,
 };
 
-use crate::graph::{EdgeHandle, Topology, TopologyMut, VertexHandle};
+use crate::graph::{Checked, EdgeHandle, Topology, TopologyMut, VertexHandle};
 
 #[derive(Debug, Default, Clone)]
 pub struct HashMapTopology {
@@ -21,6 +21,24 @@ impl HashMapTopology {
             out_edges: HashMap::new(),
             in_edges: HashMap::new(),
         }
+    }
+
+    fn checked_vertex(&self, handle: VertexHandle) -> Option<Checked<VertexHandle>> {
+        let checked = Checked::generation(handle)?;
+        if !self.vertices.contains(&checked.into_inner()) {
+            return None;
+        }
+
+        Some(checked)
+    }
+
+    fn checked_edge(&self, handle: EdgeHandle) -> Option<Checked<EdgeHandle>> {
+        let checked = Checked::generation(handle)?;
+        if !self.edges.contains_key(&checked.into_inner()) {
+            return None;
+        }
+
+        Some(checked)
     }
 }
 
@@ -69,29 +87,50 @@ impl Topology for HashMapTopology {
     }
 
     fn edge_endpoints(&self, edge: EdgeHandle) -> Option<(VertexHandle, VertexHandle)> {
-        self.edges.get(&edge).copied()
+        let checked = Checked::generation(edge)?;
+        self.edges.get(&checked.into_inner()).copied()
     }
 
     fn out_edges(&self, v: VertexHandle) -> Self::OutEdges<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return [].iter().copied(),
+        };
+
         self.out_edges
-            .get(&v)
+            .get(&checked.into_inner())
             .map(|v| v.iter())
             .unwrap_or([].iter())
             .copied()
     }
 
     fn in_edges(&self, v: VertexHandle) -> Self::InEdges<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return [].iter().copied(),
+        };
+
         self.in_edges
-            .get(&v)
+            .get(&checked.into_inner())
             .map(|v| v.iter())
             .unwrap_or([].iter())
             .copied()
     }
 
     fn out_neighbors(&self, v: VertexHandle) -> Self::OutNeighbors<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => {
+                return OutNeighbors {
+                    edges: [].iter(),
+                    edge_map: &self.edges,
+                };
+            }
+        };
+
         let edges = self
             .out_edges
-            .get(&v)
+            .get(&checked.into_inner())
             .map(|v| v.iter())
             .unwrap_or([].iter());
 
@@ -102,7 +141,21 @@ impl Topology for HashMapTopology {
     }
 
     fn in_neighbors(&self, v: VertexHandle) -> Self::InNeighbors<'_> {
-        let edges = self.in_edges.get(&v).map(|v| v.iter()).unwrap_or([].iter());
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => {
+                return InNeighbors {
+                    edges: [].iter(),
+                    edge_map: &self.edges,
+                };
+            }
+        };
+
+        let edges = self
+            .in_edges
+            .get(&checked.into_inner())
+            .map(|v| v.iter())
+            .unwrap_or([].iter());
 
         InNeighbors {
             edges,
@@ -111,12 +164,27 @@ impl Topology for HashMapTopology {
     }
 
     fn adjacent(&self, v: VertexHandle) -> Self::Adjacent<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => {
+                return Adjacent {
+                    out_edges: [].iter(),
+                    in_edges: [].iter(),
+                    edge_map: &self.edges,
+                };
+            }
+        };
+
         let out_edges = self
             .out_edges
-            .get(&v)
+            .get(&checked.into_inner())
             .map(|v| v.iter())
             .unwrap_or([].iter());
-        let in_edges = self.in_edges.get(&v).map(|v| v.iter()).unwrap_or([].iter());
+        let in_edges = self
+            .in_edges
+            .get(&checked.into_inner())
+            .map(|v| v.iter())
+            .unwrap_or([].iter());
 
         Adjacent {
             out_edges,
@@ -128,7 +196,11 @@ impl Topology for HashMapTopology {
 
 impl TopologyMut for HashMapTopology {
     fn add_vertex(&mut self, handle: VertexHandle) -> bool {
-        if !self.vertices.insert(handle) {
+        let Some(checked) = Checked::generation(handle) else {
+            return false;
+        };
+
+        if !self.vertices.insert(checked.into_inner()) {
             return false;
         }
 
@@ -139,7 +211,20 @@ impl TopologyMut for HashMapTopology {
     }
 
     fn add_edge(&mut self, handle: EdgeHandle, source: VertexHandle, target: VertexHandle) -> bool {
-        if self.edges.contains_key(&handle) {
+        let Some(checked_handle) = Checked::generation(handle) else {
+            return false;
+        };
+        let Some(checked_source) = Checked::generation(source) else {
+            return false;
+        };
+        let Some(checked_target) = Checked::generation(target) else {
+            return false;
+        };
+
+        if !self.vertices.contains(&checked_source.into_inner())
+            || !self.vertices.contains(&checked_target.into_inner())
+            || self.edges.contains_key(&checked_handle.into_inner())
+        {
             return false;
         }
 
@@ -151,7 +236,12 @@ impl TopologyMut for HashMapTopology {
     }
 
     fn remove_edge(&mut self, handle: EdgeHandle) -> bool {
-        let Some((source, target)) = self.edges.remove(&handle) else {
+        let checked = match self.checked_edge(handle) {
+            Some(checked) => checked,
+            None => return false,
+        };
+
+        let Some((source, target)) = self.edges.remove(&checked.into_inner()) else {
             return false;
         };
 
@@ -167,7 +257,12 @@ impl TopologyMut for HashMapTopology {
     }
 
     fn remove_vertex(&mut self, handle: VertexHandle) -> bool {
-        if !self.vertices.remove(&handle) {
+        let checked = match self.checked_vertex(handle) {
+            Some(checked) => checked,
+            None => return false,
+        };
+
+        if !self.vertices.remove(&checked.into_inner()) {
             return false;
         }
 

--- a/src/graph/topology/vec.rs
+++ b/src/graph/topology/vec.rs
@@ -1,4 +1,4 @@
-use crate::graph::{EdgeHandle, Topology, TopologyMut, VertexHandle};
+use crate::graph::{Checked, EdgeHandle, Topology, TopologyMut, VertexHandle};
 
 #[derive(Debug, Default, Clone)]
 pub struct VecTopology {
@@ -32,8 +32,29 @@ impl VecTopology {
         }
     }
 
+    fn checked_vertex(&self, handle: VertexHandle) -> Option<Checked<VertexHandle>> {
+        let graph = self.graph?;
+        let checked = Checked::graph_and_generation(handle, graph)?;
+        if checked.index() >= self.vertices.len() || !self.vertices[checked.index()] {
+            return None;
+        }
+
+        Some(checked)
+    }
+
+    fn checked_edge(&self, handle: EdgeHandle) -> Option<Checked<EdgeHandle>> {
+        let graph = self.graph?;
+        let checked = Checked::graph_and_generation(handle, graph)?;
+        if checked.index() >= self.edges.len() {
+            return None;
+        }
+
+        Some(checked)
+    }
+
     fn edge_ref(&self, edge: EdgeHandle) -> Option<(VertexHandle, VertexHandle)> {
-        self.edges.get(edge.index()).and_then(|entry| *entry)
+        let checked = self.checked_edge(edge)?;
+        self.edges.get(checked.index()).and_then(|entry| *entry)
     }
 }
 
@@ -104,8 +125,13 @@ impl Topology for VecTopology {
     }
 
     fn out_neighbors(&self, v: VertexHandle) -> Self::OutNeighbors<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return Vec::new().into_iter(),
+        };
+
         self.out_edges
-            .get(v.index())
+            .get(checked.index())
             .map(|edges| {
                 edges
                     .iter()
@@ -117,8 +143,13 @@ impl Topology for VecTopology {
     }
 
     fn in_neighbors(&self, v: VertexHandle) -> Self::InNeighbors<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return Vec::new().into_iter(),
+        };
+
         self.in_edges
-            .get(v.index())
+            .get(checked.index())
             .map(|edges| {
                 edges
                     .iter()
@@ -130,25 +161,40 @@ impl Topology for VecTopology {
     }
 
     fn out_edges(&self, v: VertexHandle) -> Self::OutEdges<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return Vec::new().into_iter(),
+        };
+
         self.out_edges
-            .get(v.index())
+            .get(checked.index())
             .cloned()
             .unwrap_or_default()
             .into_iter()
     }
 
     fn in_edges(&self, v: VertexHandle) -> Self::InEdges<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return Vec::new().into_iter(),
+        };
+
         self.in_edges
-            .get(v.index())
+            .get(checked.index())
             .cloned()
             .unwrap_or_default()
             .into_iter()
     }
 
     fn adjacent(&self, v: VertexHandle) -> Self::Adjacent<'_> {
+        let checked = match self.checked_vertex(v) {
+            Some(checked) => checked,
+            None => return Vec::new().into_iter(),
+        };
+
         let mut adjacent = Vec::new();
 
-        if let Some(out) = self.out_edges.get(v.index()) {
+        if let Some(out) = self.out_edges.get(checked.index()) {
             for edge in out {
                 if let Some((_, target)) = self.edge_ref(*edge) {
                     adjacent.push((target, *edge));
@@ -156,7 +202,7 @@ impl Topology for VecTopology {
             }
         }
 
-        if let Some(inn) = self.in_edges.get(v.index()) {
+        if let Some(inn) = self.in_edges.get(checked.index()) {
             for edge in inn {
                 if let Some((source, _)) = self.edge_ref(*edge) {
                     adjacent.push((source, *edge));
@@ -170,19 +216,19 @@ impl Topology for VecTopology {
 
 impl TopologyMut for VecTopology {
     fn remove_vertex(&mut self, handle: VertexHandle) -> bool {
-        let index = handle.index();
-        if index >= self.vertices.len() || !self.vertices[index] {
-            return false;
-        }
+        let checked = match self.checked_vertex(handle) {
+            Some(checked) => checked,
+            None => return false,
+        };
 
-        self.vertices[index] = false;
+        self.vertices[checked.index()] = false;
 
         let mut incident = Vec::new();
-        incident.extend(self.out_edges[index].iter().copied());
-        incident.extend(self.in_edges[index].iter().copied());
+        incident.extend(self.out_edges[checked.index()].iter().copied());
+        incident.extend(self.in_edges[checked.index()].iter().copied());
 
-        self.out_edges[index].clear();
-        self.in_edges[index].clear();
+        self.out_edges[checked.index()].clear();
+        self.in_edges[checked.index()].clear();
 
         for edge in incident {
             self.remove_edge(edge);
@@ -192,63 +238,82 @@ impl TopologyMut for VecTopology {
     }
 
     fn remove_edge(&mut self, handle: EdgeHandle) -> bool {
-        let index = handle.index();
-        let Some((source, target)) = self.edges.get_mut(index).and_then(|entry| entry.take())
+        let checked = match self.checked_edge(handle) {
+            Some(checked) => checked,
+            None => return false,
+        };
+
+        let Some((source, target)) = self
+            .edges
+            .get_mut(checked.index())
+            .and_then(|entry| entry.take())
         else {
             return false;
         };
 
         if let Some(edges) = self.out_edges.get_mut(source.index()) {
-            edges.retain(|current| *current != handle);
+            edges.retain(|current| *current != checked.into_inner());
         }
 
         if let Some(edges) = self.in_edges.get_mut(target.index()) {
-            edges.retain(|current| *current != handle);
+            edges.retain(|current| *current != checked.into_inner());
         }
 
         true
     }
 
     fn add_vertex(&mut self, handle: VertexHandle) -> bool {
+        let Some(checked) = Checked::generation(handle) else {
+            return false;
+        };
+
         if !self.ensure_graph(handle.graph()) {
             return false;
         }
 
-        let index = handle.index();
-        self.ensure_vertex_capacity(index);
+        self.ensure_vertex_capacity(checked.index());
 
-        if self.vertices[index] {
+        if self.vertices[checked.index()] {
             return false;
         }
 
-        self.vertices[index] = true;
+        self.vertices[checked.index()] = true;
         true
     }
 
     fn add_edge(&mut self, handle: EdgeHandle, source: VertexHandle, target: VertexHandle) -> bool {
+        let Some(checked_handle) = Checked::generation(handle) else {
+            return false;
+        };
+        let Some(checked_source) = Checked::generation(source) else {
+            return false;
+        };
+        let Some(checked_target) = Checked::generation(target) else {
+            return false;
+        };
+
         if !self.ensure_graph(handle.graph())
             || !self.ensure_graph(source.graph())
             || !self.ensure_graph(target.graph())
-            || source.index() >= self.vertices.len()
-            || target.index() >= self.vertices.len()
-            || !self.vertices[source.index()]
-            || !self.vertices[target.index()]
+            || checked_source.index() >= self.vertices.len()
+            || checked_target.index() >= self.vertices.len()
+            || !self.vertices[checked_source.index()]
+            || !self.vertices[checked_target.index()]
         {
             return false;
         }
 
-        let index = handle.index();
-        if self.edges.len() <= index {
-            self.edges.resize(index + 1, None);
+        if self.edges.len() <= checked_handle.index() {
+            self.edges.resize(checked_handle.index() + 1, None);
         }
 
-        if self.edges[index].is_some() {
+        if self.edges[checked_handle.index()].is_some() {
             return false;
         }
 
-        self.edges[index] = Some((source, target));
-        self.out_edges[source.index()].push(handle);
-        self.in_edges[target.index()].push(handle);
+        self.edges[checked_handle.index()] = Some((source, target));
+        self.out_edges[checked_source.index()].push(handle);
+        self.in_edges[checked_target.index()].push(handle);
         true
     }
 }

--- a/tests/safety_validation.rs
+++ b/tests/safety_validation.rs
@@ -1,0 +1,71 @@
+use sinistra::graph::{
+    BasicGraph, Graph, GraphMut, HashMapStorage, HashMapTopology, Storage, Topology, TopologyMut,
+    VecStorage, VecTopology,
+};
+
+#[test]
+fn storage_operations_reject_foreign_handles_without_panicking() {
+    let mut s1 = HashMapStorage::<&str, i32>::new();
+    let mut s2 = HashMapStorage::<&str, i32>::new();
+
+    let v1 = s1.add_vertex("A");
+    let e1 = s1.add_edge(1);
+
+    let v2 = s2.add_vertex("B");
+    let e2 = s2.add_edge(2);
+
+    assert_eq!(s1.set_vertex(v2, "X"), None);
+    assert_eq!(s1.set_edge(e2, 9), None);
+    assert_eq!(s1.remove_vertex(v2), None);
+    assert_eq!(s1.remove_edge(e2), None);
+
+    assert_eq!(s1.vertex(v1), Some(&"A"));
+    assert_eq!(s1.edge(e1), Some(&1));
+}
+
+#[test]
+fn vec_topology_rejects_cross_graph_handles() {
+    let mut g1 = BasicGraph::new(VecStorage::<(), ()>::new(), VecTopology::new());
+    let mut g2 = BasicGraph::new(VecStorage::<(), ()>::new(), VecTopology::new());
+
+    let a1 = g1.add_vertex(());
+    let b1 = g1.add_vertex(());
+    let e1 = g1.add_edge((), a1, b1);
+
+    let a2 = g2.add_vertex(());
+    let b2 = g2.add_vertex(());
+    let e2 = g2.add_edge((), a2, b2);
+
+    assert_eq!(g1.edge_endpoints(e2), None);
+    assert_eq!(g1.out_neighbors(a2).next(), None);
+    assert_eq!(g1.in_neighbors(a2).next(), None);
+    assert_eq!(g1.out_edges(a2).next(), None);
+    assert_eq!(g1.topology().adjacent(a2).next(), None);
+
+    assert_eq!(g1.remove_edge(e2), None);
+    assert_eq!(g1.remove_vertex(a2), None);
+
+    assert_eq!(g1.edge_endpoints(e1), Some((a1, b1)));
+    assert_eq!(g2.edge_endpoints(e2), Some((a2, b2)));
+}
+
+#[test]
+fn hashmap_topology_validates_vertex_membership_on_add_edge() {
+    let mut topology = HashMapTopology::new();
+    let mut s1 = HashMapStorage::<(), ()>::new();
+    let mut s2 = HashMapStorage::<(), ()>::new();
+
+    let a = s1.add_vertex(());
+    let b = s1.add_vertex(());
+    let foreign = s2.add_vertex(());
+    let e = s1.add_edge(());
+
+    assert!(topology.add_vertex(a));
+    assert!(topology.add_vertex(b));
+
+    assert!(!topology.add_edge(e, a, foreign));
+    assert_eq!(topology.edge_endpoints(e), None);
+
+    assert!(topology.add_edge(e, a, b));
+    assert_eq!(topology.edge_endpoints(e), Some((a, b)));
+}


### PR DESCRIPTION
### Motivation
- Centralize and standardize handle validation (graph discriminant and generation) to prevent panics and unsafe cross-graph access. 
- Replace ad-hoc `graph()`/`index()` checks with a typed `Checked<T>` to make correctness explicit and reusable. 

### Description
- Introduced a `Handle` trait and a `Checked<T: Handle>` wrapper in `src/graph/handle.rs` with helpers `generation` and `graph_and_generation` to validate handles. 
- Exported `Checked` and `Handle` from `src/graph/mod.rs`. 
- Reworked `HashMapStorage` and `VecStorage` to use `Checked` helpers and to return `None` for invalid/foreign handles instead of panicking, adding `checked_vertex`/`checked_edge` helpers. 
- Updated `HashMapTopology` and `VecTopology` to validate memberships and generations via `Checked`, reject foreign or stale handles, and avoid returning or iterating over invalid entries. 
- Removed many direct `assert_eq!` and manual index checks and replaced them with the `Checked`-based validation flow. 
- Added new test file `tests/safety_validation.rs` containing tests that exercise rejection of foreign handles and topology validation scenarios. 

### Testing
- Ran the test suite with `cargo test`, including the new `safety_validation` tests. 
- All tests, including `storage_operations_reject_foreign_handles_without_panicking`, `vec_topology_rejects_cross_graph_handles`, and `hashmap_topology_validates_vertex_membership_on_add_edge`, passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97ddd5e78832d82aeec1a6afda989)