### PR TITLE
Initialize DFS start vertex as `Gray` and add cycle edge-classification test

### DIFF
--- a/src/graph/algorithm/traversal/dfs.rs
+++ b/src/graph/algorithm/traversal/dfs.rs
@@ -60,7 +60,7 @@ where
         let mut stack = Vec::new();
         let mut pending = VecDeque::new();
 
-        colors.set_property(start, Color::Black);
+        colors.set_property(start, Color::Gray);
         stack.push(start);
         pending.push_back(Event::Core(TraversalEvent::Discover { vertex: start }));
 

--- a/tests/traversal_algorithms.rs
+++ b/tests/traversal_algorithms.rs
@@ -29,6 +29,27 @@ fn make_graph() -> (
     (graph, a)
 }
 
+fn make_cycle_graph() -> (
+    BasicGraph<HashMapStorage<&'static str, Cost>, HashMapTopology>,
+    VertexHandle,
+) {
+    let storage = HashMapStorage::<&str, Cost>::new();
+    let topology = HashMapTopology::new();
+    let mut graph = BasicGraph::new(storage, topology);
+
+    let a = graph.add_vertex("A");
+    let b = graph.add_vertex("B");
+    let c = graph.add_vertex("C");
+
+    graph.add_edge(Cost(1.0), a, b);
+    graph.add_edge(Cost(1.0), b, c);
+    graph.add_edge(Cost(1.0), b, b);
+    graph.add_edge(Cost(1.0), c, a);
+
+    (graph, a)
+}
+
+
 #[test]
 fn bfs_vertices_discovers_expected_set() {
     let (graph, start) = make_graph();
@@ -81,6 +102,26 @@ fn dfs_discovers_and_finishes_all_reachable_vertices() {
 
     assert_eq!(discover, 4);
     assert_eq!(finish, 4);
+}
+
+
+#[test]
+fn dfs_cycle_classifies_back_edges_for_ancestors() {
+    let (graph, start) = make_cycle_graph();
+
+    let events: Vec<_> = dfs::<_, HashMap<VertexHandle, _>>(&graph, start).collect();
+
+    let back_edge_count = events
+        .iter()
+        .filter(|event| matches!(event, DfsEvent::BackEdge { .. }))
+        .count();
+    let forward_edge_count = events
+        .iter()
+        .filter(|event| matches!(event, DfsEvent::ForwardEdge { .. }))
+        .count();
+
+    assert!(back_edge_count >= 1);
+    assert_eq!(forward_edge_count, 0);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The DFS implementation unnecessarily marked the start vertex as `Color::Black`, which prevented correct detection of back-edges during traversal of cyclic graphs.
- The change ensures the traversal state begins in-discovery so edge classification (`White/Gray/Black`) behaves according to DFS semantics.

### Description
- Change initialization in `Dfs::new` from `colors.set_property(start, Color::Black)` to `colors.set_property(start, Color::Gray)` so the start vertex is in the discovered state.
- Leave the finish-step transition to `Color::Black` unchanged to mark completed vertices correctly.
- Add a `make_cycle_graph` helper and a test `dfs_cycle_classifies_back_edges_for_ancestors` in `tests/traversal_algorithms.rs` that constructs a cyclic graph (including a self-loop) and asserts at least one `BackEdge` and no `ForwardEdge` events are emitted.
- Rechecked the edge-classification branches and retained `White => TreeEdge`, `Gray => BackEdge`, and `Black => CrossEdge` behavior.

### Testing
- Ran `cargo test --test traversal_algorithms` and all tests passed (`6 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1080f7c0832d9744cfb41fc81e25)